### PR TITLE
remove legacy code

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDSession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDSession.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Range}
-import org.apache.spark.sql.crossdata.config.CoreConfig
 import org.apache.spark.sql.crossdata.session.{XDSessionState, XDSharedState}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -42,12 +41,6 @@ class XDSession private(
                          @transient override val sparkContext: SparkContext,
                          @transient private val existingSharedState: Option[XDSharedState])
   extends SparkSession(sparkContext) with Serializable with Slf4jLoggerComponent { self =>
-
-
-  val xdConfig = userCoreConfig.fold(config) { userConf =>
-    userConf.withFallback(config)
-  }
-  val catalogConfig = Try(xdConfig.getConfig(CoreConfig.CatalogConfigKey)).getOrElse(ConfigFactory.empty())
 
 
   import XDSession.SessionId

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSharedState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSharedState.scala
@@ -20,7 +20,6 @@ import com.typesafe.config.Config
 import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalog
-import org.apache.spark.sql.crossdata.config.CoreConfig
 import org.apache.spark.sql.internal.SharedState
 
 
@@ -31,7 +30,7 @@ final class XDSharedState(
                            //val externalCatalog: XDCatalogCommon,
                            //val streamingCatalog: Option[XDStreamingCatalog],
                            //@transient val securityManager: Option[CrossdataSecurityManager]
-                         ) extends SharedState(sc) with CoreConfig{
+                         ) extends SharedState(sc) {
 
   // TODO XDCatalog Spark2.0 => SPIKE fallback? override val externalCatalog: ExternalCatalog = super.externalCatalog
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <derby.version>10.10.1.1</derby.version>
         <jackson4s.version>3.2.10</jackson4s.version>
         <mockito.version>1.10.19</mockito.version>
-        <common.utils.version>0.8.0</common.utils.version>
+        <common.utils.version>0.8.0-SNAPSHOT</common.utils.version>
         <guava.version>18.0</guava.version>
         <curator.version>3.2.0</curator.version>
         <crossdata-auth-iface.version>0.1.0</crossdata-auth-iface.version>


### PR DESCRIPTION
## Description

Remove legacy code from your code base.

*NOTE that* this PR also changes common-utils version which should be compiled and installed locally in order to use spark 2.1 dependencies.